### PR TITLE
[Documentation] Adds extra information about defining types

### DIFF
--- a/docs/src/content/docs/guides/types/defining-types.mdx
+++ b/docs/src/content/docs/guides/types/defining-types.mdx
@@ -12,7 +12,7 @@ This is a helper class to make defining types easier.
 This object is used to register the type.
 
 <Code lang="ts" code={`
-import { TransformResult, TypeBuilder } from "@rbxts/centurion";
+import { BaseRegistry, TransformResult, TypeBuilder } from "@rbxts/centurion";
 import { t } from "@rbxts/t";
 
 const playerType = TypeBuilder.create<Player>("player")
@@ -29,6 +29,10 @@ const playerType = TypeBuilder.create<Player>("player")
 	})
 	.suggestions(() => Players.GetPlayers().map((player) => player.Name))
 	.build();
+
+export = (registry: BaseRegistry) => {
+	registry.registerType(playerType);
+}
 `} />
 
 The `string` you provide to `TypeBuilder.create` will be the name of the type.

--- a/docs/src/content/docs/guides/types/defining-types.mdx
+++ b/docs/src/content/docs/guides/types/defining-types.mdx
@@ -5,6 +5,9 @@ description: Learn how to define types.
 
 import { Code } from '@astrojs/starlight/components';
 
+Types are defined in a folder where both the client and server have access to them (i.e. `ReplicatedStorage/types`).
+That way both the client and the server will be able to add your custom defined types to the registry.
+
 In order to define a type, you should use `TypeBuilder`.
 This is a helper class to make defining types easier.
 


### PR DESCRIPTION
These changes outline that you need to export a function that will add your type to the registry rather than nothing at all like how the current documentation shows it as. I couldn't figure out what was wrong with my custom types until I read the source code itself to find this information. Furthermore this adds an extra tid-bit clarifying that your custom types need to be loaded on both the client and server.